### PR TITLE
Use 'context' instead of 'canvas' to work with latest Compose.

### DIFF
--- a/src/Mamba.jl
+++ b/src/Mamba.jl
@@ -8,7 +8,7 @@ using Distributions
 import Base: Base, cor, dot
 import Base.LinAlg: Cholesky
 import Calculus: gradient
-import Compose: Canvas, canvas, cm, gridstack, inch, MeasureOrNumber, mm, pt, px
+import Compose: Context, context, cm, gridstack, inch, MeasureOrNumber, mm, pt, px
 import Distributions: Continuous, Distribution, gradlogpdf, insupport, logpdf,
        logpdf!, minimum, maximum, PDiagMat, PDMat, quantile, rand, ScalMat,
        Truncated

--- a/src/output/plot.jl
+++ b/src/output/plot.jl
@@ -101,7 +101,7 @@ function draw(p::Array{Plot}; fmt::Symbol=:svg, filename::String="",
   np = iceil(ps/pp)    ## number of pages
   ex = pp - (ps % pp)  ## number of blank plots
 
-  mat = Array(Canvas, pp)
+  mat = Array(Context, pp)
   for page in 1:np
     nrem = ps - (page-1)*pp
 
@@ -109,7 +109,7 @@ function draw(p::Array{Plot}; fmt::Symbol=:svg, filename::String="",
       if j <= nrem
         mat[j] = render(p[(page-1)*pp+j])
       else
-        mat[j] = canvas() ## pad with blank plots
+        mat[j] = context() ## pad with blank plots
       end
     end
     if page > 1


### PR DESCRIPTION
This should restore plotting with Compose 0.3.0 to fix dcjones/Compose.jl#60
