### PR TITLE
Rename BMMG to BMC3

### DIFF
--- a/doc/examples/pollution.jl
+++ b/doc/examples/pollution.jl
@@ -152,8 +152,8 @@ sim2 = mcmc(model, pollution, inits, 10000, burnin=1000, thin=2, chains=4)
 describe(sim2)
 
 
-## Binary Modified Metropolised Gibbs Sampling
-scheme3 = [BMMG([:gamma], p); scheme0]
+## Binary MCMC Model Composition
+scheme3 = [BMC3([:gamma], p); scheme0]
 setsamplers!(model, scheme3)
 sim3 = mcmc(model, pollution, inits, 10000, burnin=1000, thin=2, chains=4)
 describe(sim3)

--- a/doc/samplers.rst
+++ b/doc/samplers.rst
@@ -12,7 +12,7 @@ Listed below are the sampling methods for which functions are provided to simula
     samplers/amwg.rst
     samplers/bhmc.rst
     samplers/bmg.rst
-    samplers/bmmg.rst
+    samplers/bmc3.rst
     samplers/dgs.rst
     samplers/mala.rst
     samplers/miss.rst
@@ -37,7 +37,7 @@ The following table summarizes the (*d*-dimensional) sample spaces over which ea
     +--------------------------------------------+---------------------------------------+------------+--------------+------------+--------------+-----------------+
     | :ref:`BMG <section-BMG>`                   | :math:`\{0, 1\}^d`                    | No         | Yes          | No         | Yes          | No              |
     +--------------------------------------------+---------------------------------------+------------+--------------+------------+--------------+-----------------+
-    | :ref:`BMMG <section-BMMG>`                 | :math:`\{0, 1\}^d`                    | Yes        | Yes          | Yes        | Yes          | No              |
+    | :ref:`BMC3 <section-BMC3>`                 | :math:`\{0, 1\}^d`                    | Yes        | Yes          | Yes        | Yes          | No              |
     +--------------------------------------------+---------------------------------------+------------+--------------+------------+--------------+-----------------+
     | :ref:`DGS <section-DGS>`                   | Finite :math:`S \subset \mathbb{Z}^d` | No         | Yes          | Yes        | No           | No              |
     +--------------------------------------------+---------------------------------------+------------+--------------+------------+--------------+-----------------+

--- a/doc/samplers/bmc3.jl
+++ b/doc/samplers/bmc3.jl
@@ -18,16 +18,16 @@ logf = function(gamma::DenseVector)
   logpdf(MvNormal(X * (beta0 .* gamma), 1.0), y)
 end
 
-## MCMC Simulation with Binary Modified Metropolised Gibbs Sampling
+## MCMC Simulation with Binary MCMC Model Composition
 t = 10000
 sim = Chains(t, p, names = map(i -> "gamma[$i]", 1:p))
-gamma = BMMGVariate(zeros(p))
+gamma = BMC3Variate(zeros(p))
 indexset = collect(combinations(1:p, 1))
 for i in 1:t
-  bmmg!(gamma, indexset, logf)
+  bmc3!(gamma, indexset, logf)
   sim[i,:,1] = gamma
 end
 describe(sim)
 
 p = plot(sim, [:trace, :mixeddensity])
-draw(p, filename = "bmmgplot")
+draw(p, filename = "bmc3plot")

--- a/doc/samplers/bmc3.rst
+++ b/doc/samplers/bmc3.rst
@@ -1,19 +1,19 @@
-.. index:: Sampling Functions; Binary Modified Metropolised Gibbs
+.. index:: Sampling Functions; Binary MCMC Model Composition
 
-.. _section-BMMG:
+.. _section-BMC3:
 
-Binary Modified Metropolised Gibbs (BMMG)
+Binary MCMC Model Composition (BMC3)
 -----------------------------------------
 
-Implementation of the binary-state modified Metropolised Gibbs sampler of Schafer :cite:`schafer:2012:DIS,schafer:2013:SMCB` in which proposed updates are always state changes.  The sampler simulates autocorrelated draws from a distribution that can be specified up to a constant of proportionality.
+Implementation of the binary-state MCMC Model Composition of Madigan and York :cite:`madigan:1995:MC3` in which proposed updates are always state changes.  The sampler simulates autocorrelated draws from a distribution that can be specified up to a constant of proportionality.
 
 
 Stand-Alone Function
 ^^^^^^^^^^^^^^^^^^^^
 
-.. function:: bmmg!(v::BMMGVariate, indexset::Vector{Vector{Int}}, logf::Function)
+.. function:: bmc3!(v::BMC3Variate, indexset::Vector{Vector{Int}}, logf::Function)
 
-    Simulate one draw from a target distribution using the BMMG sampler.  Parameters are assumed to have binary numerical values (0 or 1).
+    Simulate one draw from a target distribution using the BMC3 sampler.  Parameters are assumed to have binary numerical values (0 or 1).
 
     **Arguments**
 
@@ -25,37 +25,37 @@ Stand-Alone Function
 
         Returns ``v`` updated with simulated values and associated tuning parameters.
 
-    .. _example-bmmg:
+    .. _example-bmc3:
 
     **Example**
 
-        .. literalinclude:: bmmg.jl
+        .. literalinclude:: bmc3.jl
             :language: julia
 
 
-.. index:: Sampler Types; BMMGVariate
+.. index:: Sampler Types; BMC3Variate
 
-BMMGVariate Type
+BMC3Variate Type
 ^^^^^^^^^^^^^^^^
 
 Declaration
 ```````````
 
-``BMMGVariate <: VectorVariate``
+``BMC3Variate <: VectorVariate``
 
 Fields
 ``````
 
 * ``value::Vector{Float64}`` : vector of sampled values.
-* ``tune::BMMGTune`` : tuning parameters for the sampling algorithm.
+* ``tune::BMC3Tune`` : tuning parameters for the sampling algorithm.
 
 Constructors
 ````````````
 
-.. function:: BMMGVariate(x::Vector{Float64}, tune::BMMGTune)
-              BMMGVariate(x::Vector{Float64}, tune=nothing)
+.. function:: BMC3Variate(x::Vector{Float64}, tune::BMC3Tune)
+              BMC3Variate(x::Vector{Float64}, tune=nothing)
 
-    Construct a ``BMMGVariate`` object that stores sampled values and tuning parameters for BMMG sampling.
+    Construct a ``BMC3Variate`` object that stores sampled values and tuning parameters for BMC3 sampling.
 
     **Arguments**
 
@@ -64,17 +64,17 @@ Constructors
 
     **Value**
 
-        Returns a ``BMMGVariate`` type object with fields pointing to the values supplied to arguments ``x`` and ``tune``.
+        Returns a ``BMC3Variate`` type object with fields pointing to the values supplied to arguments ``x`` and ``tune``.
 
-.. index:: Sampler Types; BMMGTune
+.. index:: Sampler Types; BMC3Tune
 
-BMMGTune Type
+BMC3Tune Type
 ^^^^^^^^^^^^^
 
 Declaration
 ```````````
 
-``type BMMGTune``
+``type BMC3Tune``
 
 Fields
 ``````
@@ -85,10 +85,10 @@ Fields
 Sampler Constructor
 ^^^^^^^^^^^^^^^^^^^
 
-.. function:: BMMG(params::Vector{Symbol}, d::Integer, k::Integer=1)
-              BMMG(params::Vector{Symbol}, indexset::Vector{Vector{Int}})
+.. function:: BMC3(params::Vector{Symbol}, d::Integer, k::Integer=1)
+              BMC3(params::Vector{Symbol}, indexset::Vector{Vector{Int}})
 
-    Construct a ``Sampler`` object for BMMG sampling.  Parameters are assumed to have binary numerical values (0 or 1).
+    Construct a ``Sampler`` object for BMC3 sampling.  Parameters are assumed to have binary numerical values (0 or 1).
 
     **Arguments**
 

--- a/doc/xrefs.bib
+++ b/doc/xrefs.bib
@@ -463,6 +463,16 @@
   address =      {Boca Raton, FL}
 }
 
+@ARTICLE{madigan:1995:MC3,
+  AUTHOR  =      {Madigan, D and York, J and Allard, D},
+  TITLE   =      {Bayesian Graphical Models for Discrete Data},
+  JOURNAL =      {Revue Internationale de Statistique},
+  YEAR    =      {1995},
+  volume  =      {63},
+  number  =      {2},
+  pages   =      {215--232}
+}
+
 @MANUAL{martin:2013:MCP,
   title  = {{MCMCpack}: {M}arkov Chain {M}onte {C}arlo {(MCMC)} Package},
   author = {Martin, A D and Quinn, K M and Park, J H},

--- a/src/Mamba.jl
+++ b/src/Mamba.jl
@@ -192,7 +192,7 @@ module Mamba
   include("samplers/amwg.jl")
   include("samplers/bmg.jl")
   include("samplers/bhmc.jl")
-  include("samplers/bmmg.jl")
+  include("samplers/bmc3.jl")
   include("samplers/dgs.jl")
   include("samplers/mala.jl")
   include("samplers/miss.jl")
@@ -285,9 +285,9 @@ module Mamba
     bhmc!,
     BHMC,
     BHMCVariate,
-    bmmg!,
-    BMMG,
-    BMMGVariate,
+    bmc3!,
+    BMC3,
+    BMC3Variate,
     dgs!,
     DGS,
     DGSVariate,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ test_samplers = [
   "amwg",
   "bmg",
   "bhmc",
-  "bmmg",
+  "bmc3",
   "mala",
   "nuts",
   "slice",


### PR DESCRIPTION
I’ve discovered that the first time this algorithm was described was probably in 1995 and they referred to it as MCMC Model Composition (MC3). The original paper allowed the different "models" to be general (not necessarily defined by a vector of binary values) so I think Binary MC3 makes sense as a name. I've updated the name and documentation. 