### PR TITLE
ABC Sampler

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -60,5 +60,6 @@ Additional examples are provided below to further illustrate features of the pac
 .. toctree::
     :maxdepth: 1
 
+    examples/abc.rst
     examples/line_amwg_slice.rst
     examples/pollution.rst

--- a/doc/examples/abc.jl
+++ b/doc/examples/abc.jl
@@ -1,0 +1,68 @@
+################################################################################
+## Linear Regression
+##   y ~ N(b0 + b1 * x, s2)
+##   b0, b1 ~ N(0, 1000)
+##   s2 ~ invgamma(0.001, 0.001)
+################################################################################
+
+using Mamba
+
+## Data
+line = Dict{Symbol, Any}(
+  :x => [1, 2, 3, 4, 5],
+  :y => [1, 3, 3, 3, 5]
+)
+
+line[:xmat] = [ones(5) line[:x]]
+
+## Model Specification
+
+model = Model(
+
+  y = Stochastic(1,
+    (mu, s2) -> MvNormal(mu, sqrt(s2)),
+    false
+  ),
+
+  mu = Logical(1,
+    (xmat, beta) -> xmat * beta,
+    false
+  ),
+
+  beta = Stochastic(1,
+    () -> MvNormal(2, sqrt(1000))
+  ),
+
+  s2 = Stochastic(
+    () -> InverseGamma(0.001, 0.001)
+  )
+
+)
+
+## Initial Values
+inits = [
+  Dict{Symbol, Any}(
+    :y => line[:y],
+    :beta => rand(Normal(0, 1), 2),
+    :s2 => rand(Gamma(1, 1))
+  )
+  for i in 1:3
+]
+
+## summary Statistics
+summarize = [identity, mean]
+
+epsilon1 = 0.7
+sigma1 = 1.0
+
+epsilon2 = 0.85
+sigma2 = 8.0
+
+## User-Defined Sampling Scheme
+scheme = [ABC([:beta], sigma1, summarize, epsilon1, s = 1, n = 100, kernel = :gaussian),
+          ABC([:s2],   sigma2, summarize, epsilon2, s = 1, n = 120, kernel = :epanechnikov)]
+setsamplers!(model, scheme)
+
+## MCMC Simulation with Approximate Bayesian Computing
+sim = mcmc(model, line, inits, 10000, burnin=1000, thin=1, chains=3)
+describe(sim)

--- a/doc/examples/abc.rst
+++ b/doc/examples/abc.rst
@@ -1,0 +1,37 @@
+.. index:: Examples; Approximate Bayesian Computing
+
+.. _example-ABC:
+
+Approximate Bayesian Computing
+------------------------------
+
+A simple example to demonstrate the Approximate Bayesian Computing sampler within the MCMC framework based on the linear regression model defined in the :ref:`section-Line` section.
+
+Analysis Program
+^^^^^^^^^^^^^^^^
+
+.. literalinclude:: abc.jl
+       :language: julia
+
+Results
+^^^^^^^
+
+.. code-block:: julia
+
+    Iterations = 1001:10000
+    Thinning interval = 1
+    Chains = 1,2,3
+    Samples per chain = 9000
+    
+    Empirical Posterior Estimates:
+               Mean        SD       Naive SE       MCSE       ESS   
+    beta[1] 0.63133698 1.30979294 0.0079711460 0.049024555 713.80234
+    beta[2] 0.79995255 0.38169153 0.0023229007 0.012115902 992.46124
+         s2 1.18427121 2.49666395 0.0151942129 0.131048462 362.95796
+    
+    Quantiles:
+                2.5%        25.0%       50.0%     75.0%      97.5%  
+    beta[1] -1.841697099 -0.09055321 0.59443124 1.2937670  3.3970011
+    beta[2]  0.039303260  0.58749126 0.80036075 1.0210728  1.5305396
+         s2  0.009203774  0.14104046 0.36967615 0.9555609 13.3210173
+

--- a/doc/samplers.rst
+++ b/doc/samplers.rst
@@ -8,6 +8,7 @@ Listed below are the sampling methods for which functions are provided to simula
 .. toctree::
     :maxdepth: 1
 
+    samplers/abc.rst
     samplers/amm.rst
     samplers/amwg.rst
     samplers/bhmc.rst
@@ -30,6 +31,8 @@ The following table summarizes the (*d*-dimensional) sample spaces over which ea
     +--------------------------------------------+---------------------------------------+------------+--------------+-----------------+------------+--------------+
     | Method                                     | Sample Space                          | Univariate | Multivariate | Transformations | Univariate | Multivariate |
     +============================================+=======================================+============+==============+=================+============+==============+
+    | :ref:`ABC <section-ABC>`                   | :math:`\mathbb{R}^d`                  | No         | Yes          | Yes             | No         | No           |
+    +--------------------------------------------+---------------------------------------+------------+--------------+-----------------+------------+--------------+
     | :ref:`AMM <section-AMM>`                   | :math:`\mathbb{R}^d`                  | No         | Yes          | Yes             | No         | Yes          |
     +--------------------------------------------+---------------------------------------+------------+--------------+-----------------+------------+--------------+
     | :ref:`AMWG <section-AMWG>`                 | :math:`\mathbb{R}^d`                  | Yes        | No           | Yes             | Yes        | No           |

--- a/doc/samplers/abc.rst
+++ b/doc/samplers/abc.rst
@@ -1,0 +1,33 @@
+.. index:: Sampling Functions; Approximate Bayesian Computing
+
+.. _section-ABC:
+
+Approximate Bayesian Computing
+------------------------------
+
+Approximate Bayesian Computing in the framework of MCMC (also known as Likelihood-Free MCMC) as proposed by :cite:`marjoram:2003:abc` for simulating autocorrelated draws from a distribution that can be specified up to a constant of proportionality. Also see :cite:`sisson:2011:ABC` for a thorough review of Likelihood-Free MCMC. 
+
+Sampler Constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. function:: ABC(params::Vector{Symbol}, sigma::Real, summarize::Vector{Function}, \
+                  target::Real; rho::Function = (x, y) -> sqrt(sumabs2(x - y)), \
+                  s::Int = 1, n::Int = 50, kernel::Symbol = :uniform)
+
+    Construct a ``Sampler`` object for ABC sampling.  Parameters are assumed to be continuous and unconstrained. 
+
+    **Arguments**
+
+        * ``params`` : stochastic nodes to be updated with the sampler.  Constrained parameters are mapped to unconstrained space according to transformations defined by the :ref:`section-Stochastic` ``link()`` function.
+        * ``sigma`` : Proposal is drawn from normal distribution centered at previous draw with ``sigma`` variance. 
+        * ``summarize`` : A vector of functions to compute summary statistics for the data.
+        * ``target`` : The target cut-off parameter to determine how close simulated data needs to be to accept proposal. The cut-off parameter used in each iteration is monotonically decreased to this target. 
+        * ``rho`` : A distance function to compute distance between simulated data and real data. Default is Euclidean distance. 
+        * ``s`` : Number of data sets to simulate for each proposal. 
+        * ``n`` : Number of simulations to accept new proposal before staying with current value.
+        * ``kernel`` : Weighting density kernel. One of :uniform, :epanechnikov, :gaussian
+
+    **Value**
+
+        Returns a ``Sampler`` type object.
+

--- a/doc/xrefs.bib
+++ b/doc/xrefs.bib
@@ -492,6 +492,16 @@
   pages   =      {215--232}
 }
 
+@ARTICLE{marjoram:2003:abc,
+  TITLE   =      {{M}arkov chain {M}onte {C}arlo without likelihoods},
+  AUTHOR  =      {Marjoram, P and Molitor, J and Plagnol, V and Tavar\'{e}, S},
+  JOURNAL =      {Proceedings of the National Academy of Sciences of the United States of America},
+  YEAR    =      {2003},
+  volume  =      {100},
+  number  =      {26},
+  pages   =      {15324--15328}
+}
+
 @MANUAL{martin:2013:MCP,
   title  = {{MCMCpack}: {M}arkov Chain {M}onte {C}arlo {(MCMC)} Package},
   author = {Martin, A D and Quinn, K M and Park, J H},
@@ -732,6 +742,16 @@
   volume  =      {23},
   number  =      {2},
   pages   =      {163-184}
+}
+
+@INBOOK{sisson:2011:ABC,
+  AUTHOR =       {Sisson, S A and Fan, Y},
+  editor =       {Brooks, Steve and Gelman, Andrew and Jones, Galin L and Meng, Xiao-Li},
+  TITLE =        {Handbook of Markov Chain Monte Carlo},
+  CHAPTER =      {Likelihood-Free MCMC},
+  pages =        {313--335},
+  PUBLISHER =    {CRC Press},
+  YEAR =         {2011},
 }
 
 @ARTICLE{smith:2007:BOA,

--- a/src/Mamba.jl
+++ b/src/Mamba.jl
@@ -202,6 +202,7 @@ module Mamba
   include("output/stats.jl")
   include("output/plot.jl")
 
+  include("samplers/abc.jl")
   include("samplers/amm.jl")
   include("samplers/amwg.jl")
   include("samplers/bhmc.jl")
@@ -291,6 +292,7 @@ module Mamba
     update!
 
   export
+    ABC,
     amm!,
     AMM,
     AMMVariate,

--- a/src/samplers/abc.jl
+++ b/src/samplers/abc.jl
@@ -1,0 +1,140 @@
+#################### Approximate Bayesian Computing ####################
+
+#################### Types and Constructors ####################
+
+type ABCTune
+  Told::Matrix{Float64}
+  epsilon::Vector{Float64}
+  terminals::Vector{Symbol}
+end
+
+ABCTune() = ABCTune(Matrix{Float64}(), Vector{Float64}(), Vector{Symbol}())
+
+function ABC(params::Vector{Symbol}, sigma::Real, summarize::Vector{Function},
+             target::Real; rho::Function = (x, y) -> sqrt(sumabs2(x - y)),
+             s::Integer = 1, n::Integer = 50, kernel::Symbol = :uniform)
+
+  kernel in [:uniform, :epanechnikov, :gaussian] ||
+    throw(ArgumentError(
+      "kernel must be one of :uniform, :epanechnikov, or :gaussian"
+    ))
+
+  samplerfx = function(model::Model, block::Integer)
+    tunepar = tune(model, block)
+
+    ## previous value
+    x = unlist(model, block, true)
+    logfx = mapreduce(p -> logpdf(model[p], true), +, params)
+    
+
+    T0 = NaN
+    Told = NaN
+    Tnew = NaN
+
+    ## Initialize tune
+    if model.iter == 1
+      terminals = keys(model, :output)
+      nt = length(terminals)
+
+      ## data
+      dvec = map(node -> unlist(model, [node]), terminals)
+
+      ## summary stat of data
+      T0vec = Array(Array{Float64, 1}, nt)
+      for d in 1:nt
+        T0vec[d] = vcat(map(f -> f(dvec[d]), summarize)...)
+      end
+      T0 = vcat(T0vec...)
+
+      m = length(T0)
+
+      Told = zeros(m, s)
+      eps0 = zeros(s)
+      for i in 1:s
+        Toldvec = Array(Array{Float64, 1}, nt)
+        for d in 1:nt
+          x0 = unlist(model[terminals[d]], rand(model[terminals[d]]))
+          Toldvec[d] = vcat(map(f -> f(x0), summarize)...)
+        end
+        Told[:, i] = vcat(Toldvec...)
+        eps0[i] = rho(Told[:, i], T0)
+      end
+      tunepar.Told = Told
+      tunepar.epsilon = eps0
+      tunepar.terminals = terminals
+    else
+      nt = length(tunepar.terminals)
+      ## data
+      dvec = map(node -> unlist(model, [node]), tunepar.terminals)
+
+      ## summary stat of data
+      T0vec = Array(Array{Float64, 1}, nt)
+      for d in 1:nt
+        T0vec[d] = vcat(map(f -> f(dvec[d]), summarize)...)
+      end
+      T0 = vcat(T0vec...)
+      Told = tunepar.Told
+    end
+
+    nt = length(tunepar.terminals)
+
+    ## Attempt n times to get new proposal
+    for k in 1:n
+      ## proposal
+      y = x + sigma * randn(length(x))
+      relist!(model, y, block, true)
+      logfy = mapreduce(p -> logpdf(model[p], true), +, params)
+
+      ratio_num = 0.0
+      ratio_den = 0.0
+
+      Tnew = zeros(length(T0), s)
+      epsilon = zeros(s)
+
+      ## Simulate s data sets
+      for i in 1:s
+        ## new data
+        Tnewvec = Array(Array{Float64, 1}, nt)
+        for d in 1:nt
+          x0 = unlist(model[tunepar.terminals[d]], rand(model[tunepar.terminals[d]]))
+          Tnewvec[d] = vcat(map(f -> f(x0), summarize)...)
+        end
+
+        ## summary stat of new data
+        Tnew[:, i] = vcat(Tnewvec...)
+
+        ## Monotonically decrease epsilon to target
+        epsilon[i] = max(target, min(rho(Tnew[:, i], T0), tunepar.epsilon[i]))
+
+        ## weighting density
+        rho0 = 0
+        rho1 = 0
+        if kernel == :uniform
+          rho0 = pdf(Uniform(0, epsilon[i]), rho(Told[:, i], T0))
+          rho1 = pdf(Uniform(0, epsilon[i]), rho(Tnew[:, i], T0))
+        elseif kernel == :epanechnikov
+          rho0 = prod([pdf(Epanechnikov(Told[j, i], epsilon[i]), T0[j]) 
+                       for j in 1:length(T0)])
+          rho1 = prod([pdf(Epanechnikov(Tnew[j, i], epsilon[i]), T0[j]) 
+                       for j in 1:length(T0)])
+        elseif kernel == :gaussian
+          rho0 = pdf(MvNormal(collect(Told[:, i]), epsilon[i]), collect(T0))
+          rho1 = pdf(MvNormal(collect(Tnew[:, i]), epsilon[i]), collect(T0))
+        end
+
+        ratio_num += rho1
+        ratio_den += rho0
+      end
+
+      ## Reject/Accept
+      if rand() < ratio_num / ratio_den * exp(logfy - logfx)
+        x[:] = y
+        tunepar.Told = Tnew
+        tunepar.epsilon = epsilon
+        break
+      end
+    end
+    relist(model, x, block, true)
+  end
+  Sampler(params, samplerfx, ABCTune())
+end

--- a/test/runexamples.jl
+++ b/test/runexamples.jl
@@ -28,6 +28,7 @@ const openbugstests = [
 ]
 
 const contributedtests = [
+  "abc",
   "line_amwg_slice",
   "pollution"
 ]


### PR DESCRIPTION
Updated to new Sampler notation. The line results look to be in line with the other Bayesian linear regression results. I've tweaked the sampler parameters so that the sampling is reasonably quick (about a minute per chain). If you decrease the parameter ``n`` in the example to about 50 it takes about 20 seconds per chain, but the results a a bit nosier. 