### PR TITLE
Bring back indexset to BMC3 sampler

### DIFF
--- a/src/samplers/bmc3.jl
+++ b/src/samplers/bmc3.jl
@@ -11,6 +11,9 @@ type BMC3Tune <: SamplerTune
 
   BMC3Tune(x::Vector, logf::Nullable{Function}; k::Integer=1) =
     new(logf, k, Vector{Vector{Int}}())
+
+  BMC3Tune(x::Vector, logf::Nullable{Function}, indexset::Vector{Vector{Int}}) = 
+    new(logf, 0, indexset)
 end
 
 BMC3Tune(x::Vector; args...) =
@@ -48,7 +51,12 @@ sample!(v::BMC3Variate) = sample!(v, v.tune.logf)
 
 function sample!(v::BMC3Variate, logf::Function)
   x = v[:]
-  idx = randperm(length(v))[1:v.tune.k]
+  idx = Int64[]
+  if length(v.tune.indexset) > 0
+    idx = rand(v.tune.indexset)
+  else
+    idx = randperm(length(v))[1:v.tune.k]
+  end
   x[idx] = 1.0 - v[idx]
   if rand() < exp(logf(x) - logf(v.value))
     v[:] = x


### PR DESCRIPTION
Ability to specify BMC3 sampler with custom indexset was lost with commit 85721e3c095544e545440019ec07aea95a46ba40 