### PR TITLE
Bmc3/adaptive

### DIFF
--- a/doc/samplers/bmc3.rst
+++ b/doc/samplers/bmc3.rst
@@ -5,7 +5,7 @@
 Binary MCMC Model Composition (BMC3)
 ------------------------------------
 
-Implementation of the binary-state MCMC Model Composition of Madigan and York :cite:`madigan:1995:MC3` in which proposed updates are always state changes. Liu :cite:`liu:1996:MMG` shows this sampler is more efficient than Gibbs sampling for a binary vector. Schafer :cite:`schafer:2012:DIS,schafer:2013:SMCB` proposes a method for block updates of binary vectors using this sampler. The sampler simulates autocorrelated draws from a distribution that can be specified up to a constant of proportionality.
+Implementation of the binary-state MCMC Model Composition of Madigan and York :cite:`madigan:1995:MC3` in which proposed updates are always state changes. Liu :cite:`liu:1996:MMG` shows this sampler is more efficient than Gibbs sampling for a binary vector. Schafer :cite:`schafer:2012:DIS,schafer:2013:SMCB` proposes a method for block updates of binary vectors using this sampler. An adaptive version of this sampler is proposed in `lamnisos:2013:AMC3`. The sampler simulates autocorrelated draws from a distribution that can be specified up to a constant of proportionality.
 
 Model-Based Constructor
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ Fields
 Constructor
 ```````````
 
-.. function:: BMC3Variate(x::AbstractVector{T<:Real}, logf::Function; k::Integer=1)
+.. function:: BMC3Variate(x::AbstractVector{T<:Real}, logf::Function; k::Integer=1, indexset::Vector{Vector{Int}}=Vector{Vector{Int}}(), epsilon::Float64=1/length(x))
 
     Construct a ``BMC3Variate`` object that stores simulated values and tuning parameters for BMC3 sampling.
 
@@ -73,7 +73,9 @@ Constructor
 
         * ``x`` : initial values.
         * ``logf`` : function that takes a single ``DenseVector`` argument of parameter values at which to compute the log-transformed density (up to a normalizing constant).
-        * ``k`` : number of parameters to select at random for simultaneous updating in each call of the sampler.
+        * ``k`` : number of parameters to select at random for simultaneous updating in each call of the sampler. Used if ``indexset`` is not specified. 
+        * ``indexset`` : A set of the sets of parameters to select at random for simultaneous updating in ecah call of the sampler. 
+        * ``epsilon`` : If sampling is specified to be adaptive, a parameter is selected to be updated by a mixture of a discrete distribution depending on the current MCMC sample and a uniform distribution, where ``epsilon`` is the mixture weight. 
 
     **Value**
 
@@ -93,4 +95,9 @@ Fields
 ``````
 
 * ``logf::Nullable{Function}`` : function supplied to the constructor to compute the log-transformed density, or null if not supplied.
-* ``k::Int`` : number of parameters to select at random for simultaneous updating in each call of the sampler.
+* ``k::Int`` : number of parameters to select at random for simultaneous updating in each call of the sampler. Used if ``indexset`` is not specified. 
+* ``indexset::Vector{Vector{Int}}`` : A set of the set of parameters to select at random for simultaneous updating in each call of the sampler. 
+* ``n::Int`` : current iteration.
+* ``m::Vector{Float64}`` : current inclusion frequency, i.e. mean. 
+* ``v::Vector{Float64}`` : current sample variance.
+* ``epsilon::Float64`` : If sampling is specified to be adaptive, a parameter is selected to be updated by a mixture of a discrete distribution depending on the current MCMC sample and a uniform distribution, where ``epsilon`` is the mixture weight.

--- a/doc/xrefs.bib
+++ b/doc/xrefs.bib
@@ -446,6 +446,15 @@
   address =      {New York},
 }
 
+@ARTICLE{lamnisos:2013:AMC3,
+  author  = {Lamnisos, D and Griffin, J E and Steel, M F J},
+  title   = {Adaptive MC\textsuperscript{3} and Gibbs Algorithms for
+             Bayesian Model Averaging in Linear Regression Models},
+  journal = {arXiv:1306.6028 [stat.CO]},
+  year    = {2013},
+  url     = {http://arxiv.org/abs/1306.6028}
+}
+
 @MANUAL{lin:2014:SBP,
   title  = {StatsBase},
   author = {Lin, D and Byrne, S and Jensen, A N and Bates, D and White, J M and

--- a/src/Mamba.jl
+++ b/src/Mamba.jl
@@ -41,7 +41,7 @@ module Mamba
          out_edges, out_neighbors, target, topological_sort_by_dfs, vertices
   import Showoff: showoff
   import StatsBase: autocor, autocov, countmap, counts, describe, predict,
-         quantile, sem, summarystats
+         quantile, sem, summarystats, wsample
 
   include("distributions/pdmats2.jl")
   importall .PDMats2

--- a/src/samplers/bmc3.jl
+++ b/src/samplers/bmc3.jl
@@ -7,11 +7,18 @@ type BMC3Tune <: SamplerTune
   k::Int
   indexset::Vector{Vector{Int}}
 
+  n::Int
+  m::Vector{Float64}
+  v::Vector{Float64}
+
+  epsilon::Float64
+
   BMC3Tune() = new()
 
   BMC3Tune(x::Vector, logf::Nullable{Function}; k::Integer=1, 
-           indexset::Vector{Vector{Int}} = Vector{Vector{Int}}()) =
-    new(logf, k, indexset)
+           indexset::Vector{Vector{Int}} = Vector{Vector{Int}}(),
+           epsilon::Float64 = 1/length(x)) =
+    new(logf, k, indexset, 0, zeros(length(x)), zeros(length(x)), epsilon)
 end
 
 BMC3Tune(x::Vector; args...) =
@@ -32,11 +39,15 @@ end
 
 #################### Sampler Constructor ####################
 
-function BMC3(params::ElementOrVector{Symbol}; args...)
+function BMC3(params::ElementOrVector{Symbol}; adapt::Symbol = :none, args...)
+
+  adapt in [:var, :freq, :none] || 
+    throw(ArgumentError("adapt must be one of :var, :freq, or :none"))
+    
   samplerfx = function(model::Model, block::Integer)
     block = SamplingBlock(model, block)
     v = SamplerVariate(block; args...)
-    sample!(v, x -> logpdf!(block, x))
+    sample!(v, x -> logpdf!(block, x), adapt=adapt)
     relist(block, v)
   end
   Sampler(params, samplerfx, BMC3Tune())
@@ -45,15 +56,29 @@ end
 
 #################### Sampling Functions ####################
 
-sample!(v::BMC3Variate) = sample!(v, v.tune.logf)
+sample!(v::BMC3Variate; args...) = sample!(v, v.tune.logf; args...)
 
-function sample!(v::BMC3Variate, logf::Function)
+function sample!(v::BMC3Variate, logf::Function; adapt::Symbol = :none)
   x = v[:]
+
+  ## online calculation of mean and variance
+  v.tune.n += 1
+  d = x - v.tune.m
+  v.tune.m += d/v.tune.n
+  v.tune.v += d .* (x - v.tune.m)
+
   idx = Int64[]
-  if length(v.tune.indexset) > 0
-    idx = rand(v.tune.indexset)
+  if adapt == :var
+    idx = wsample(1:length(v), 
+            (1 - v.tune.epsilon) * (v.tune.v / (v.tune.n - 1)) + v.tune.epsilon)
+  elseif adapt == :freq
+    idx = wsample(1:length(v), (1 - v.tune.epsilon) * v.tune.m + v.tune.epsilon)
   else
-    idx = randperm(length(v))[1:v.tune.k]
+    if length(v.tune.indexset) > 0
+      idx = rand(v.tune.indexset)
+    else
+      idx = randperm(length(v))[1:v.tune.k]
+    end
   end
   x[idx] = 1.0 - v[idx]
   if rand() < exp(logf(x) - logf(v.value))

--- a/src/samplers/bmc3.jl
+++ b/src/samplers/bmc3.jl
@@ -9,8 +9,9 @@ type BMC3Tune <: SamplerTune
 
   BMC3Tune() = new()
 
-  BMC3Tune(x::Vector, logf::Nullable{Function}; k::Integer=1) =
-    new(logf, k, Vector{Vector{Int}}())
+  BMC3Tune(x::Vector, logf::Nullable{Function}; k::Integer=1, 
+           indexset::Vector{Vector{Int}} = Vector{Vector{Int}}()) =
+    new(logf, k, indexset)
 end
 
 BMC3Tune(x::Vector; args...) =
@@ -48,7 +49,12 @@ sample!(v::BMC3Variate) = sample!(v, v.tune.logf)
 
 function sample!(v::BMC3Variate, logf::Function)
   x = v[:]
-  idx = randperm(length(v))[1:v.tune.k]
+  idx = Int64[]
+  if length(v.tune.indexset) > 0
+    idx = rand(v.tune.indexset)
+  else
+    idx = randperm(length(v))[1:v.tune.k]
+  end
   x[idx] = 1.0 - v[idx]
   if rand() < exp(logf(x) - logf(v.value))
     v[:] = x

--- a/src/samplers/bmc3.jl
+++ b/src/samplers/bmc3.jl
@@ -2,87 +2,130 @@
 
 #################### Types and Constructors ####################
 
-type BMC3Tune <: SamplerTune
-  logf::Nullable{Function}
-  k::Int
-  indexset::Vector{Vector{Int}}
+typealias BMC3Form Union{Int, Vector{Vector{Int}}}
 
+type BMC3Tune{F<:BMC3Form} <: SamplerTune
+  logf::Nullable{Function}
+  indices::F
   n::Int
   m::Vector{Float64}
   v::Vector{Float64}
-
   epsilon::Float64
 
   BMC3Tune() = new()
 
-  BMC3Tune(x::Vector, logf::Nullable{Function}; k::Integer=1, 
-           indexset::Vector{Vector{Int}} = Vector{Vector{Int}}(),
-           epsilon::Float64 = 1/length(x)) =
-    new(logf, k, indexset, 0, zeros(length(x)), zeros(length(x)), epsilon)
+  BMC3Tune(x::Vector, indices::F; args...) =
+    BMC3Tune{F}(x, indices, Nullable{Function}(); args...)
+
+  BMC3Tune(x::Vector, indices::F, logf::Function; args...) =
+    BMC3Tune{F}(x, indices, Nullable{Function}(logf); args...)
+
+  BMC3Tune(x::Vector, indices::F, logf::Nullable{Function};
+           epsilon::Real=1 / length(x)) =
+    new(logf, indices, 0, zeros(x), zeros(x), epsilon)
 end
 
-BMC3Tune(x::Vector; args...) =
-   BMC3Tune(x, Nullable{Function}(); args...)
 
-BMC3Tune(x::Vector, logf::Function; args...) =
-   BMC3Tune(x, Nullable{Function}(logf); args...)
+BMC3Variate(x::Vector; k::Integer=1, args...) =
+   SamplerVariate{BMC3Tune{Int}}(x, k; args...)
+
+BMC3Variate(x::Vector, logf::Function; k::Integer=1, args...) =
+   SamplerVariate{BMC3Tune{Int}}(x, k, logf; args...)
+
+BMC3Variate(x::Vector, indexset::Vector{Vector{Int}}; args...) =
+  SamplerVariate{BMC3Tune{Vector{Vector{Int}}}}(x, indexset; args...)
+
+BMC3Variate(x::Vector, indexset::Vector{Vector{Int}}, logf::Function; args...) =
+  SamplerVariate{BMC3Tune{Vector{Vector{Int}}}}(x, indexset, logf; args...)
 
 
-typealias BMC3Variate SamplerVariate{BMC3Tune}
-
-function validate(v::BMC3Variate)
+function validate(v::SamplerVariate{BMC3Tune{Int}})
   n = length(v)
-  v.tune.k <= n || throw(ArgumentError("k exceeds variate length $n"))
+  v.tune.indices <= n ||
+    throw(ArgumentError("indices exceed variate length $n"))
+  validatebinary(v)
+end
+
+function validate(v::SamplerVariate{BMC3Tune{Vector{Vector{Int}}}})
+  n = length(v)
+  mapreduce(maximum, max, v.tune.indices) <= n ||
+    throw(ArgumentError("indices exceed variate length $n"))
   validatebinary(v)
 end
 
 
 #################### Sampler Constructor ####################
 
-function BMC3(params::ElementOrVector{Symbol}; adapt::Symbol = :none, args...)
+function BMC3(params::ElementOrVector{Symbol}; k::Integer=1, args...)
+  BMC3Sampler(params, k; args...)
+end
 
-  adapt in [:var, :freq, :none] || 
-    throw(ArgumentError("adapt must be one of :var, :freq, or :none"))
-    
+function BMC3(params::ElementOrVector{Symbol}, indexset::Vector{Vector{Int}};
+              args...)
+  BMC3Sampler(params, indexset; args...)
+end
+
+function BMC3Sampler{F<:BMC3Form}(params::ElementOrVector{Symbol}, indices::F;
+                                  adapt::Symbol=:none, atype::Symbol=:var,
+                                  args...)
+  adapt in [:all, :burnin, :none] ||
+    throw(ArgumentError("adapt must be one of :all, :burnin, or :none"))
+  atype in [:var, :freq] ||
+    throw(ArgumentError("atype must be one of :var or :freq"))
+
   samplerfx = function(model::Model, block::Integer)
     block = SamplingBlock(model, block)
-    v = SamplerVariate(block; args...)
-    sample!(v, x -> logpdf!(block, x), adapt=adapt)
+    v = SamplerVariate(block, indices; args...)
+    isadapt = adapt == :burnin ? model.iter <= model.burnin :
+              adapt == :all ? true : false
+    sample!(v, x -> logpdf!(block, x), adapt=isadapt, atype=atype)
     relist(block, v)
   end
-  Sampler(params, samplerfx, BMC3Tune())
+  Sampler(params, samplerfx, BMC3Tune{F}())
 end
 
 
 #################### Sampling Functions ####################
 
-sample!(v::BMC3Variate; args...) = sample!(v, v.tune.logf; args...)
+sample!{F<:BMC3Form}(v::SamplerVariate{BMC3Tune{F}}; args...) =
+  sample!(v, v.tune.logf; args...)
 
-function sample!(v::BMC3Variate, logf::Function; adapt::Symbol = :none)
+function sample!{F<:BMC3Form}(v::SamplerVariate{BMC3Tune{F}}, logf::Function;
+                              adapt::Bool=false, atype::Symbol=:var)
   x = v[:]
-
-  ## online calculation of mean and variance
-  v.tune.n += 1
-  d = x - v.tune.m
-  v.tune.m += d/v.tune.n
-  v.tune.v += d .* (x - v.tune.m)
-
-  idx = Int64[]
-  if adapt == :var
-    idx = wsample(1:length(v), 
-            (1 - v.tune.epsilon) * (v.tune.v / (v.tune.n - 1)) + v.tune.epsilon)
-  elseif adapt == :freq
-    idx = wsample(1:length(v), (1 - v.tune.epsilon) * v.tune.m + v.tune.epsilon)
-  else
-    if length(v.tune.indexset) > 0
-      idx = rand(v.tune.indexset)
-    else
-      idx = randperm(length(v))[1:v.tune.k]
-    end
-  end
+  setadapt!(v, adapt)
+  idx = randind(v, atype)
   x[idx] = 1.0 - v[idx]
   if rand() < exp(logf(x) - logf(v.value))
     v[:] = x
   end
   v
 end
+
+function randind(v::SamplerVariate{BMC3Tune{Int}}, atype)
+  wv =  atype == :var ?
+        (1 - v.tune.epsilon) * (v.tune.v / (v.tune.n - 1)) + v.tune.epsilon :
+        (1 - v.tune.epsilon) * v.tune.m + v.tune.epsilon
+  sample(1:length(v), wv, v.tune.indices)
+end
+
+function randind(v::SamplerVariate{BMC3Tune{Vector{Vector{Int}}}})
+  wv =  atype == :var ?
+        (1 - v.tune.epsilon) * (v.tune.v / (v.tune.n - 1)) + v.tune.epsilon :
+        (1 - v.tune.epsilon) * v.tune.m + v.tune.epsilon
+  wvb = zeros(length(v.tune.indices))
+  for i in 1:length(v.tune.indices)
+    wvb[i] = mean(wv[v.tune.indices[i]])
+  end
+  sample(v.tune.indices, wvb)
+end
+
+function setadapt!(v::BMC3Variate, adapt::Bool)
+  if adapt
+    v.tune.n += 1
+    d = v.value - v.tune.m
+    v.tune.m += d / v.tune.n
+    v.tune.v += d .* (x - v.tune.m)
+  end
+end
+


### PR DESCRIPTION
This includes commit to make BMC3 adaptive, and reintroduce ability to specify indexset (supersedes pull request https://github.com/brian-j-smith/Mamba.jl/pull/89). Documentation is included as well. 