### PR TITLE
Update modelchains.jl

### DIFF
--- a/src/output/modelchains.jl
+++ b/src/output/modelchains.jl
@@ -27,7 +27,7 @@ function names2inds(mc::ModelChains, nodekeys::Vector{Symbol})
   missing = Symbol[]
   for key in nodekeys
     keyinds = indexin(names(mc.model, key), mc.names)
-    0 in keyinds ? push!(missing, key) : append!(inds, keyinds)
+    nothing in keyinds ? push!(missing, key) : append!(inds, keyinds)
   end
   if !isempty(missing)
     throw(ArgumentError(string(


### PR DESCRIPTION
`findin` now returns `nothing` for elements in first set that are not in 2nd set. See https://github.com/JuliaLang/julia/blob/master/HISTORY.md